### PR TITLE
✨ Enable non-downsampled raw data ("full") runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0]
+
+### Added
+
+- Support for "full" (non-downsampled) integration tests.
+
 ## [1.0.0]
 
 Initial release. See [README](https://github.com/childmindresearch/slurm_testing/blob/v1.0.0/README.md).

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Set up a GitHub Actions workflow configuration file to call [`cpac-slurm-status 
 
 ```BASH
 sbatch \
-  cpac_slurm_status launch \
+  cpac_slurm_status lite launch \
   --wd="${{ env.SSH_WORK_DIR }}/logs/${{ github.sha }}" \
   --comparison-path="${{ env.COMPARISON_PATH }}" \
   --dashboard-repo="${{ env.DASHBOARD_REPO}}" \

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ graph TD;
 
 ### Launch a 'lite' regression test run
 
-Set up a GitHub Actions workflow configuration file to call [`cpac-slurm-status launch`](./src/cpac_slurm_testing/status/cli.py#L209-L222). Use contexts, secrets and environment variables to pass the required variables to the script from GitHub Actions.
+Set up a GitHub Actions workflow configuration file to call [`cpac-slurm-status lite launch`](./src/cpac_slurm_testing/status/cli.py#L146-L150). Use contexts, secrets and environment variables to pass the required variables to the script from GitHub Actions.
 
 #### Required commandline parameters or environment variables
 
@@ -95,7 +95,7 @@ Note: All jobs run through SLURM; this graph only shows which jobs retrieve info
 graph TD
 SLURM([SLURM]) --> updateRunStatuses;
 
-launch[[<code>sbatch cpac-slurm-status launch</code>]] --> launch_subgraph;
+launch[[<code>sbatch cpac-slurm-status lite launch</code>]] --> launch_subgraph;
 
 subgraph TotalStatus
    direction LR
@@ -117,7 +117,7 @@ subgraph launch_subgraph[launch.launch]
   build_image --success--> regtest_lite.sh
 
   regtest_lite.sh[<code>sbatch regression_run_scripts/regtest_lite.sh</code>]
---<code>for PIPELINE in ${PRECONFIGS}; do for DATA in ${DATA_SOURCE}; do for SUBJECT_PATH in ''${DATAPATH}''/sub-*; do</code>--> add["<code>cpac-slurm-status add --wd=${OUT} --data_source=${DATA} --preconfig=${PIPELINE} --subject=${SUBJECT}</code>"]
+--<code>for PIPELINE in ${PRECONFIGS}; do for DATA in ${DATA_SOURCE}; do for SUBJECT_PATH in ''${DATAPATH}''/sub-*; do</code>--> add["<code>cpac-slurm-status lite add --wd=${OUT} --data_source=${DATA} --preconfig=${PIPELINE} --subject=${SUBJECT}</code>"]
 
   add --> NamedTemporaryFile[write and run <code>NamedTemporaryFile</code> based on template in <code>templates</code>]
 end

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ graph TD;
 
 ### Launch a 'lite' regression test run
 
-Set up a GitHub Actions workflow configuration file to call [`cpac-slurm-status lite launch`](./src/cpac_slurm_testing/status/cli.py#L146-L150). Use contexts, secrets and environment variables to pass the required variables to the script from GitHub Actions.
+Set up a GitHub Actions workflow configuration file to call [`cpac-slurm-status lite launch`](./src/cpac_slurm_testing/status/cli.py#L155-L160). Use contexts, secrets and environment variables to pass the required variables to the script from GitHub Actions.
 
 #### Required commandline parameters or environment variables
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Amy Gutierrez <58920810+amygutierrez@users.noreply.github.com>", "Jo
 license = "LGPL-2.1"
 readme = "README.md"
 packages = [{include = "cpac_slurm_testing", from = "src"}]
-repository = "https://github.com/childmindresearch/slurm_testing"
+repository = "https://github.com/shnizzedy/slurm_testing"
 
 [tool.poetry.build]
 generate-setup-file = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Amy Gutierrez <58920810+amygutierrez@users.noreply.github.com>", "Jo
 license = "LGPL-2.1"
 readme = "README.md"
 packages = [{include = "cpac_slurm_testing", from = "src"}]
-repository = "https://github.com/shnizzedy/slurm_testing"
+repository = "https://github.com/childmindresearch/C-PAC_slurm_testing"
 
 [tool.poetry.build]
 generate-setup-file = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cpac_slurm_testing"
-version = "1.0.0"
+version = "1.1.0"
 description = "Run C-PAC regression tests via Slurm."
 authors = ["Amy Gutierrez <58920810+amygutierrez@users.noreply.github.com>", "Jon Clucas <jon.clucas@@childmind.org>"]
 license = "LGPL-2.1"

--- a/src/cpac_slurm_testing/launch.py
+++ b/src/cpac_slurm_testing/launch.py
@@ -9,7 +9,7 @@ import subprocess
 from cpac_slurm_testing.git_remote import GitRemoteInfo
 from cpac_slurm_testing.status import TestingPaths, TotalStatus
 from cpac_slurm_testing.status._global import get_logger, SBATCH_START
-from cpac_slurm_testing.utils import PATH_OR_STR
+from cpac_slurm_testing.utils import PathStr
 
 LOGGER: Logger = get_logger(name=__name__)
 
@@ -19,9 +19,9 @@ class LaunchParameters:
     """Parameters for launching a regression test."""
 
     testing_paths: TestingPaths
-    comparison_path: PATH_OR_STR = ""
+    comparison_path: PathStr = ""
     dashboard_repo: str = ""
-    home_dir: PATH_OR_STR = ""
+    home_dir: PathStr = ""
     image: str = ""
     owner: str = ""
     path_extra: str = ""
@@ -29,7 +29,7 @@ class LaunchParameters:
     sha: str = ""
     slurm_testing_branch: str = ""
     slurm_testing_repo: str = ""
-    token_file: PATH_OR_STR = ""
+    token_file: PathStr = ""
     _: KW_ONLY
     dry_run: bool = False
 

--- a/src/cpac_slurm_testing/launch.py
+++ b/src/cpac_slurm_testing/launch.py
@@ -110,7 +110,7 @@ def launch(parameters: LaunchParameters) -> None:
             slurm_env,
             f"--output={parameters.testing_paths.log_dir}/launch.out.log",
             f"--error={parameters.testing_paths.log_dir}/launch.err.log",
-            str(repo / "regression_run_scripts/regtest_lite.sh"),
+            str(repo / f"regression_run_scripts/regtest_{parameters.scope}.sh"),
         ]
     if parameters.dry_run:
         cmd = [*cmd, "--dry-run"]

--- a/src/cpac_slurm_testing/launch.py
+++ b/src/cpac_slurm_testing/launch.py
@@ -72,9 +72,16 @@ class LaunchParameters:
     def as_environment_variables(self) -> dict[str, str]:
         """Return a dictionary of environment variable keys and values."""
         return {
-            key.upper(): str(value.wd) if key == "testing_paths" else str(value)
-            for key, value in asdict(self).items()
-            if key != "dry_run"
+            **{
+                key.upper(): str(value.wd) if key == "testing_paths" else str(value)
+                for key, value in asdict(self).items()
+                if key != "dry_run"
+            },
+            **{
+                key.upper(): getattr(self, key)
+                for key in ["cpac_regtest_script"]
+                if hasattr(self, key)
+            },
         }
 
     @property
@@ -90,6 +97,14 @@ def launch(parameters: LaunchParameters) -> None:
     )
     with as_file(files("cpac_slurm_testing")) as repo:
         assert isinstance(parameters.home_dir, Path)
+        regtest_dir = repo / "regression_run_scripts"
+        if parameters.scope == "full":
+            setattr(
+                parameters,
+                "cpac_regtest_script",
+                str(repo / "regression_run_scripts/regtest_full.py"),
+            )
+
         slurm_env = parameters.as_slurm_export
         build: list[str] = [
             *SBATCH_START[:-1],
@@ -110,7 +125,7 @@ def launch(parameters: LaunchParameters) -> None:
             slurm_env,
             f"--output={parameters.testing_paths.log_dir}/launch.out.log",
             f"--error={parameters.testing_paths.log_dir}/launch.err.log",
-            str(repo / f"regression_run_scripts/regtest_{parameters.scope}.sh"),
+            str(regtest_dir / f"regtest_{parameters.scope}.sh"),
         ]
     if parameters.dry_run:
         cmd = [*cmd, "--dry-run"]

--- a/src/cpac_slurm_testing/launch.py
+++ b/src/cpac_slurm_testing/launch.py
@@ -9,7 +9,7 @@ import subprocess
 from cpac_slurm_testing.git_remote import GitRemoteInfo
 from cpac_slurm_testing.status import TestingPaths, TotalStatus
 from cpac_slurm_testing.status._global import get_logger, SBATCH_START
-from cpac_slurm_testing.utils import PathStr, Scope
+from cpac_slurm_testing.utils import ExistingPath, PathStr, Scope
 
 LOGGER: Logger = get_logger(name=__name__)
 
@@ -85,7 +85,9 @@ class LaunchParameters:
 
 def launch(parameters: LaunchParameters) -> None:
     """Launch a regression test."""
-    build_dir = Path(parameters.home_dir) / "automatic_tests/build" / parameters.sha
+    build_dir = ExistingPath(
+        Path(parameters.home_dir) / "automatic_tests/build" / parameters.sha
+    )
     with as_file(files("cpac_slurm_testing")) as repo:
         assert isinstance(parameters.home_dir, Path)
         slurm_env = parameters.as_slurm_export

--- a/src/cpac_slurm_testing/launch.py
+++ b/src/cpac_slurm_testing/launch.py
@@ -9,7 +9,7 @@ import subprocess
 from cpac_slurm_testing.git_remote import GitRemoteInfo
 from cpac_slurm_testing.status import TestingPaths, TotalStatus
 from cpac_slurm_testing.status._global import get_logger, SBATCH_START
-from cpac_slurm_testing.utils import PathStr
+from cpac_slurm_testing.utils import PathStr, Scope
 
 LOGGER: Logger = get_logger(name=__name__)
 
@@ -26,6 +26,7 @@ class LaunchParameters:
     owner: str = ""
     path_extra: str = ""
     repo: str = ""
+    scope: Scope = "lite"
     sha: str = ""
     slurm_testing_branch: str = ""
     slurm_testing_repo: str = ""
@@ -95,7 +96,7 @@ def launch(parameters: LaunchParameters) -> None:
             "--parsable",
             str(repo / "regression_run_scripts/build_image.sh"),
             "--working_dir",
-            f"{parameters.home_dir / 'lite' / parameters.sha}",
+            f"{parameters.home_dir / parameters.scope / parameters.sha}",
             "--image",
             f"{parameters.image}",
         ]
@@ -122,6 +123,7 @@ def launch(parameters: LaunchParameters) -> None:
     )
     status = TotalStatus(
         testing_paths=parameters.testing_paths,
+        scope=parameters.scope,
         home_dir=parameters.home_dir,
         image=parameters.sha,
         dry_run=parameters.dry_run,

--- a/src/cpac_slurm_testing/launch.py
+++ b/src/cpac_slurm_testing/launch.py
@@ -85,18 +85,19 @@ class LaunchParameters:
 
 def launch(parameters: LaunchParameters) -> None:
     """Launch a regression test."""
+    build_dir = Path(parameters.home_dir) / "automatic_tests/build" / parameters.sha
     with as_file(files("cpac_slurm_testing")) as repo:
         assert isinstance(parameters.home_dir, Path)
         slurm_env = parameters.as_slurm_export
         build: list[str] = [
             *SBATCH_START[:-1],
             slurm_env,
-            f"--output={parameters.testing_paths.log_dir}/build.out.log",
-            f"--error={parameters.testing_paths.log_dir}/build.err.log",
+            f"--output={build_dir}/build.out.log",
+            f"--error={build_dir}/build.err.log",
             "--parsable",
             str(repo / "regression_run_scripts/build_image.sh"),
             "--working_dir",
-            f"{parameters.home_dir / 'automatic_tests' / parameters.sha}",
+            f"{build_dir}",
             "--image",
             f"{parameters.image}",
         ]

--- a/src/cpac_slurm_testing/launch.py
+++ b/src/cpac_slurm_testing/launch.py
@@ -96,7 +96,7 @@ def launch(parameters: LaunchParameters) -> None:
             "--parsable",
             str(repo / "regression_run_scripts/build_image.sh"),
             "--working_dir",
-            f"{parameters.home_dir / parameters.scope / parameters.sha}",
+            f"{parameters.home_dir / parameters.sha / parameters.scope}",
             "--image",
             f"{parameters.image}",
         ]

--- a/src/cpac_slurm_testing/launch.py
+++ b/src/cpac_slurm_testing/launch.py
@@ -96,7 +96,7 @@ def launch(parameters: LaunchParameters) -> None:
             "--parsable",
             str(repo / "regression_run_scripts/build_image.sh"),
             "--working_dir",
-            f"{parameters.home_dir / parameters.sha / parameters.scope}",
+            f"{parameters.home_dir / 'automatic_tests' / parameters.sha}",
             "--image",
             f"{parameters.image}",
         ]

--- a/src/cpac_slurm_testing/launch.py
+++ b/src/cpac_slurm_testing/launch.py
@@ -60,7 +60,8 @@ class LaunchParameters:
 
         Parameters
         ----------
-        List of keys to exclude
+        except_for
+            list of keys to exclude
         """
         return [
             key

--- a/src/cpac_slurm_testing/launch.py
+++ b/src/cpac_slurm_testing/launch.py
@@ -86,7 +86,7 @@ class LaunchParameters:
 def launch(parameters: LaunchParameters) -> None:
     """Launch a regression test."""
     build_dir = ExistingPath(
-        Path(parameters.home_dir) / "automatic_tests/build" / parameters.sha
+        Path(parameters.home_dir) / "automatic_tests/images" / parameters.sha
     )
     with as_file(files("cpac_slurm_testing")) as repo:
         assert isinstance(parameters.home_dir, Path)

--- a/src/cpac_slurm_testing/pipeline_configs/default-5mm.yaml
+++ b/src/cpac_slurm_testing/pipeline_configs/default-5mm.yaml
@@ -1,7 +1,7 @@
 %YAML 1.1
 ---
 # CPAC Pipeline Configuration YAML file
-# Version 1.8.6.dev1
+# Version 1.8.8.dev1
 #
 # http://fcp-indi.github.io for more info.
 FROM: default
@@ -31,8 +31,6 @@ registration_workflows:
   anatomical_registration:
     registration:
       FSL-FNIRT:
-        ref_mask_res-2: /reg-data/tissuepriors/MNI152_T1_2mm_brain_mask_dil.nii.gz
-        T1w_template_res-2: /reg-data/tissuepriors/MNI152_T1_2mm.nii.gz
         ref_mask: /reg-data/tissuepriors/MNI152_T1_${resolution_for_anat}_brain_mask_dil.nii.gz
     resolution_for_anat: 5mm
     T1w_brain_template: /reg-data/templates/MNI152_T1_${resolution_for_anat}_brain.nii.gz
@@ -69,3 +67,7 @@ voxel_mirrored_homotopic_connectivity:
     T1w_template_symmetric_for_resample: /reg-data/templates/MNI152_T1_5mm_symmetric.nii.gz
     dilated_symmetric_brain_mask: /reg-data/templates/MNI152_T1_${resolution_for_anat}_brain_mask_symmetric_dil.nii.gz
     dilated_symmetric_brain_mask_for_resample: /reg-data/templates/MNI152_T1_5mm_brain_mask_symmetric_dil.nii.gz
+surface_analysis:
+  abcd_prefreesurfer_prep:
+    ref_mask_res-2: /reg-data/tissuepriors/MNI152_T1_2mm_brain_mask_dil.nii.gz
+    T1w_template_res-2: /reg-data/tissuepriors/MNI152_T1_2mm.nii.gz

--- a/src/cpac_slurm_testing/regression_run_scripts/build_image.sh
+++ b/src/cpac_slurm_testing/regression_run_scripts/build_image.sh
@@ -24,8 +24,8 @@ cat << TMP > "build_${IMAGE_NAME}.sh"
 
 set -x
 
-export APPTAINER_CACHEDIR="${working_dir}/.apptainer/cache" \
-       APPTAINER_LOCALCACHEDIR="${working_dir}/.apptainer/tmp"
+export APPTAINER_CACHEDIR="${HOME_DIR}/.apptainer/cache" \
+       APPTAINER_LOCALCACHEDIR="${HOME_DIR}/.apptainer/tmp"
 yes | apptainer cache clean
 yes | apptainer build --force "${working_dir}/${IMAGE_NAME}.sif" "docker://${image}"
 

--- a/src/cpac_slurm_testing/regression_run_scripts/build_image.sh
+++ b/src/cpac_slurm_testing/regression_run_scripts/build_image.sh
@@ -13,7 +13,7 @@ for _DIR in cache tmp
 do
     mkdir -p "${working_dir}/.apptainer/${_DIR}"
 done
-mkdir -p "${HOME_DIR}/automatic_tests/build/${SHA}"
+mkdir -p "${HOME_DIR}/automatic_tests/images/${SHA}"
 IMAGE_PATH="${working_dir}/${IMAGE_NAME}.sif"
 cat << TMP > "build_${IMAGE_NAME}.sh"
 #!/usr/bin/bash
@@ -21,8 +21,8 @@ cat << TMP > "build_${IMAGE_NAME}.sh"
 #SBATCH -p RM-shared
 #SBATCH -t 1:00:00
 #SBATCH --ntasks=4
-#SBATCH -o "${HOME_DIR}/automatic_tests/build/${SHA}/build.out.log"
-#SBATCH --error "${HOME_DIR}/automatic_tests/build/${SHA}/build.err.log"
+#SBATCH -o "${HOME_DIR}/automatic_tests/images/${SHA}/build.out.log"
+#SBATCH --error "${HOME_DIR}/automatic_tests/images/${SHA}/build.err.log"
 
 set -x
 

--- a/src/cpac_slurm_testing/regression_run_scripts/build_image.sh
+++ b/src/cpac_slurm_testing/regression_run_scripts/build_image.sh
@@ -29,7 +29,7 @@ set -x
 export APPTAINER_CACHEDIR="${HOME_DIR}/.apptainer/cache" \
        APPTAINER_LOCALCACHEDIR="${HOME_DIR}/.apptainer/tmp"
 yes | apptainer cache clean
-yes | apptainer build --force "${IMAGE_PATH} "docker://${image}"
+yes | apptainer build --force "${IMAGE_PATH}" "docker://${image}"
 
 if [ -e "${IMAGE_PATH}" ]
 then

--- a/src/cpac_slurm_testing/regression_run_scripts/build_image.sh
+++ b/src/cpac_slurm_testing/regression_run_scripts/build_image.sh
@@ -31,13 +31,6 @@ export APPTAINER_CACHEDIR="${HOME_DIR}/.apptainer/cache" \
 yes | apptainer cache clean
 yes | apptainer build --force "${IMAGE_PATH}" "docker://${image}"
 
-if [ -e "${IMAGE_PATH}" ]
-then
-  exit 0
-else
-  exit 2
-fi
-
 TMP
 
 chmod +x "build_${IMAGE_NAME}.sh"

--- a/src/cpac_slurm_testing/regression_run_scripts/build_image.sh
+++ b/src/cpac_slurm_testing/regression_run_scripts/build_image.sh
@@ -19,8 +19,8 @@ cat << TMP > "build_${IMAGE_NAME}.sh"
 #SBATCH -p RM-shared
 #SBATCH -t 1:00:00
 #SBATCH --ntasks=4
-#SBATCH -o "${HOME_DIR}/logs/${SHA}/build.out.log"
-#SBATCH --error "${HOME_DIR}/logs/${SHA}/build.err.log"
+#SBATCH -o "${HOME_DIR}/automatic_tests/${SHA}/build.out.log"
+#SBATCH --error "${HOME_DIR}/automatic_tests/${SHA}/build.err.log"
 
 set -x
 

--- a/src/cpac_slurm_testing/regression_run_scripts/build_image.sh
+++ b/src/cpac_slurm_testing/regression_run_scripts/build_image.sh
@@ -14,6 +14,7 @@ do
     mkdir -p "${working_dir}/.apptainer/${_DIR}"
 done
 mkdir -p "${HOME_DIR}/automatic_tests/build/${SHA}"
+IMAGE_PATH="${working_dir}/${IMAGE_NAME}.sif"
 cat << TMP > "build_${IMAGE_NAME}.sh"
 #!/usr/bin/bash
 #SBATCH -N 1
@@ -28,7 +29,14 @@ set -x
 export APPTAINER_CACHEDIR="${HOME_DIR}/.apptainer/cache" \
        APPTAINER_LOCALCACHEDIR="${HOME_DIR}/.apptainer/tmp"
 yes | apptainer cache clean
-yes | apptainer build --force "${working_dir}/${IMAGE_NAME}.sif" "docker://${image}"
+yes | apptainer build --force "${IMAGE_PATH} "docker://${image}"
+
+if [ -e "${IMAGE_PATH}" ]
+then
+  exit 0
+else
+  exit 2
+fi
 
 TMP
 

--- a/src/cpac_slurm_testing/regression_run_scripts/build_image.sh
+++ b/src/cpac_slurm_testing/regression_run_scripts/build_image.sh
@@ -13,14 +13,15 @@ for _DIR in cache tmp
 do
     mkdir -p "${working_dir}/.apptainer/${_DIR}"
 done
+mkdir -p "${HOME_DIR}/automatic_tests/build/${SHA}"
 cat << TMP > "build_${IMAGE_NAME}.sh"
 #!/usr/bin/bash
 #SBATCH -N 1
 #SBATCH -p RM-shared
 #SBATCH -t 1:00:00
 #SBATCH --ntasks=4
-#SBATCH -o "${HOME_DIR}/automatic_tests/${SHA}/build.out.log"
-#SBATCH --error "${HOME_DIR}/automatic_tests/${SHA}/build.err.log"
+#SBATCH -o "${HOME_DIR}/automatic_tests/build/${SHA}/build.out.log"
+#SBATCH --error "${HOME_DIR}/automatic_tests/build/${SHA}/build.err.log"
 
 set -x
 

--- a/src/cpac_slurm_testing/regression_run_scripts/regtest_full.py
+++ b/src/cpac_slurm_testing/regression_run_scripts/regtest_full.py
@@ -15,7 +15,9 @@ from cpac_slurm_testing.utils.datapaths import datapaths, list_site_subjects, SI
 def add(ns: SlurmTestingNamespace) -> None:
     """Add a full run to the SLURM queue."""
     for site in SITES:
-        for subject in list_site_subjects(getattr(datapaths[ns.scope], site.lower())):
+        for subject in list_site_subjects(
+            getattr(datapaths[ns.scope], site.lower())(ns.home_dir)
+        ):
             for preconfig in ns.preconfigs:
                 _ns = copy(ns)
                 _ns.data_source = site

--- a/src/cpac_slurm_testing/regression_run_scripts/regtest_full.py
+++ b/src/cpac_slurm_testing/regression_run_scripts/regtest_full.py
@@ -15,17 +15,22 @@ from cpac_slurm_testing.utils.datapaths import datapaths, list_site_subjects, SI
 def add(ns: SlurmTestingNamespace) -> None:
     """Add a full run to the SLURM queue."""
     for site in SITES:
-        for subject in list_site_subjects(
-            getattr(datapaths[ns.scope](ns.home_dir), site.lower())
-        ):
-            for preconfig in ns.preconfigs:
-                _ns = copy(ns)
-                _ns.data_source = site
-                _ns.preconfig = preconfig
-                _ns.subject = subject
-                status = TotalStatus(testing_paths=ns.testing_paths, dry_run=ns.dry_run)
-                status.update(_ns)
-                del _ns
+        try:
+            for subject in list_site_subjects(
+                getattr(datapaths[ns.scope](ns.home_dir), site.lower())
+            ):
+                for preconfig in ns.preconfigs:
+                    _ns = copy(ns)
+                    _ns.data_source = site
+                    _ns.preconfig = preconfig
+                    _ns.subject = subject
+                    status = TotalStatus(
+                        testing_paths=ns.testing_paths, dry_run=ns.dry_run
+                    )
+                    status.update(_ns)
+                    del _ns
+        except AttributeError:
+            continue
 
 
 def main() -> None:

--- a/src/cpac_slurm_testing/regression_run_scripts/regtest_full.py
+++ b/src/cpac_slurm_testing/regression_run_scripts/regtest_full.py
@@ -1,0 +1,52 @@
+"""
+Run a full regression test.
+
+Currently this script relies on a C-PAC image being available from a lite run.
+"""
+from copy import copy
+from types import SimpleNamespace
+
+from cpac_slurm_testing.status.cli import SlurmTestingNamespace
+from cpac_slurm_testing.status.status import TotalStatus
+from cpac_slurm_testing.utils.datapaths import datapaths, list_site_subjects, SITES
+
+
+def add(ns: SlurmTestingNamespace) -> None:
+    """Add a full run to the SLURM queue."""
+    for site in SITES:
+        for subject in list_site_subjects(getattr(datapaths[ns.scope], site.lower())):
+            for preconfig in ns.preconfigs:
+                _ns = copy(ns)
+                _ns.data_source = site
+                _ns.preconfig = preconfig
+                _ns.subject = subject
+                status = TotalStatus(testing_paths=ns.testing_paths, dry_run=ns.dry_run)
+                status.update(_ns)
+                del _ns
+
+
+def main() -> None:
+    """Run a full regression test."""
+    namespace = SlurmTestingNamespace(
+        SimpleNamespace(
+            command="add",
+            scope="full",
+            **{
+                _: None
+                for _ in [
+                    "data_source",
+                    "home_dir",
+                    "image_name",
+                    "out",
+                    "preconfigs",
+                    "sha",
+                    "wd",
+                ]
+            },
+        )
+    )
+    add(namespace)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cpac_slurm_testing/regression_run_scripts/regtest_full.py
+++ b/src/cpac_slurm_testing/regression_run_scripts/regtest_full.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 Run a full regression test.
 

--- a/src/cpac_slurm_testing/regression_run_scripts/regtest_full.py
+++ b/src/cpac_slurm_testing/regression_run_scripts/regtest_full.py
@@ -16,7 +16,7 @@ def add(ns: SlurmTestingNamespace) -> None:
     """Add a full run to the SLURM queue."""
     for site in SITES:
         for subject in list_site_subjects(
-            getattr(datapaths[ns.scope], site.lower())(ns.home_dir)
+            getattr(datapaths[ns.scope](ns.home_dir), site.lower())
         ):
             for preconfig in ns.preconfigs:
                 _ns = copy(ns)

--- a/src/cpac_slurm_testing/regression_run_scripts/regtest_full.py
+++ b/src/cpac_slurm_testing/regression_run_scripts/regtest_full.py
@@ -25,7 +25,9 @@ def add(ns: SlurmTestingNamespace) -> None:
                     _ns.preconfig = preconfig
                     _ns.subject = subject
                     status = TotalStatus(
-                        testing_paths=ns.testing_paths, dry_run=ns.dry_run
+                        testing_paths=ns.testing_paths,
+                        scope=ns.scope,
+                        dry_run=ns.dry_run,
                     )
                     status.update(_ns)
                     del _ns

--- a/src/cpac_slurm_testing/regression_run_scripts/regtest_full.py
+++ b/src/cpac_slurm_testing/regression_run_scripts/regtest_full.py
@@ -5,6 +5,7 @@ Run a full regression test.
 Currently this script relies on a C-PAC image being available from a lite run.
 """
 from copy import copy
+from trace import Trace
 from types import SimpleNamespace
 
 from cpac_slurm_testing.status.cli import SlurmTestingNamespace
@@ -59,4 +60,5 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    tracer = Trace(trace=True)
+    tracer.run("main()")

--- a/src/cpac_slurm_testing/regression_run_scripts/regtest_full.py
+++ b/src/cpac_slurm_testing/regression_run_scripts/regtest_full.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python3
-"""
-Run a full regression test.
-
-Currently this script relies on a C-PAC image being available from a lite run.
-"""
+"""Run a full regression test."""
 from copy import copy
 from trace import Trace
 from types import SimpleNamespace

--- a/src/cpac_slurm_testing/regression_run_scripts/regtest_full.py
+++ b/src/cpac_slurm_testing/regression_run_scripts/regtest_full.py
@@ -8,17 +8,25 @@ from copy import copy
 from trace import Trace
 from types import SimpleNamespace
 
+from cpac_slurm_testing.git_remote import GitRemoteInfo
 from cpac_slurm_testing.status.cli import SlurmTestingNamespace
 from cpac_slurm_testing.status.status import TotalStatus
-from cpac_slurm_testing.utils.datapaths import datapaths, list_site_subjects, SITES
+from cpac_slurm_testing.utils.datapaths import (
+    datapaths,
+    list_site_subjects,
+    RawDataNotFound,
+    SITES,
+)
+
+_TRACER = Trace(trace=True)
 
 
-def add(ns: SlurmTestingNamespace) -> None:
+def add(ns: SlurmTestingNamespace, git_remote: GitRemoteInfo) -> None:
     """Add a full run to the SLURM queue."""
     for site in SITES:
         try:
             for subject in list_site_subjects(
-                getattr(datapaths[ns.scope](ns.home_dir), site.lower())
+                getattr(datapaths[ns.scope](ns.home_dir), site)
             ):
                 for preconfig in ns.preconfigs.split(" "):
                     _ns = copy(ns)
@@ -26,13 +34,16 @@ def add(ns: SlurmTestingNamespace) -> None:
                     _ns.preconfig = preconfig
                     _ns.subject = subject
                     status = TotalStatus(
+                        image=ns.sha,
+                        home_dir=ns.home_dir,
                         testing_paths=ns.testing_paths,
                         scope=ns.scope,
                         dry_run=ns.dry_run,
+                        git_remote=git_remote,
                     )
                     status.update(_ns)
                     del _ns
-        except AttributeError:
+        except RawDataNotFound:
             continue
 
 
@@ -51,14 +62,24 @@ def main() -> None:
                     "out",
                     "preconfigs",
                     "sha",
+                    "token_file",
                     "wd",
                 ]
             },
         )
     )
-    add(namespace)
+    with open(namespace.token_file, "r", encoding="utf8") as _token_file:
+        github_token: str = _token_file.read().strip()
+        if "GITHUB_TOKEN=" in github_token:
+            github_token = github_token.split("GITHUB_TOKEN=", 1)[1]
+    git_remote = GitRemoteInfo(
+        owner="FCP-INDI",
+        repo="C-PAC",
+        sha=namespace.sha,
+        token=github_token,
+    )
+    add(namespace, git_remote)
 
 
 if __name__ == "__main__":
-    tracer = Trace(trace=True)
-    tracer.run("main()")
+    main()

--- a/src/cpac_slurm_testing/regression_run_scripts/regtest_full.py
+++ b/src/cpac_slurm_testing/regression_run_scripts/regtest_full.py
@@ -20,7 +20,7 @@ def add(ns: SlurmTestingNamespace) -> None:
             for subject in list_site_subjects(
                 getattr(datapaths[ns.scope](ns.home_dir), site.lower())
             ):
-                for preconfig in ns.preconfigs:
+                for preconfig in ns.preconfigs.split(" "):
                     _ns = copy(ns)
                     _ns.data_source = site
                     _ns.preconfig = preconfig

--- a/src/cpac_slurm_testing/regression_run_scripts/regtest_full.sh
+++ b/src/cpac_slurm_testing/regression_run_scripts/regtest_full.sh
@@ -11,5 +11,6 @@ export _CPAC_STATUS_PRECONFIGS="default"
 export _CPAC_STATUS_SHA="${SHA}"
 export _CPAC_STATUS_DATA_SOURCE="Site-CBIC Site-SI HNU_1"
 export _CPAC_STATUS_WD="${WD}"
+SCRIPT_DIR="$(dirname "$0")"
 # shellcheck disable=SC1090
-source "${TOKEN_FILE}" && ./regtest_full.py
+source "${TOKEN_FILE}" && "${SCRIPT_DIR}/regtest_full.py"

--- a/src/cpac_slurm_testing/regression_run_scripts/regtest_full.sh
+++ b/src/cpac_slurm_testing/regression_run_scripts/regtest_full.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/bash
+
+# Required environment variables: $COMPARISON_PATH, $GH_AVAILABLE, $HOME_DIR, $IMAGE, $OWNER, $PATH, $PUSH_LOGS, $REPO, $SHA, $SLURM_TESTING_REPO, $SLURM_TESTING_BRANCH, $TOKEN_FILE
+
+set -x
+
+export _CPAC_STATUS_HOME_DIR="${HOME_DIR}"
+export _CPAC_STATUS_IMAGE_NAME="${SHA#*:}"
+export _CPAC_STATUS_OUT="${HOME_DIR}/full/${_CPAC_STATUS_IMAGE_NAME}"
+export _CPAC_STATUS_PRECONFIGS="default"
+export _CPAC_STATUS_SHA="${SHA}"
+export _CPAC_STATUS_DATA_SOURCE="Site-CBIC Site-SI HNU_1"
+export _CPAC_STATUS_WD="${WD}"
+# shellcheck disable=SC1090
+source "${TOKEN_FILE}" && ./regtest_full.py

--- a/src/cpac_slurm_testing/regression_run_scripts/regtest_full.sh
+++ b/src/cpac_slurm_testing/regression_run_scripts/regtest_full.sh
@@ -12,6 +12,4 @@ export _CPAC_STATUS_SHA="${SHA}"
 export _CPAC_STATUS_DATA_SOURCE="Site-CBIC Site-SI HNU_1"
 export _CPAC_STATUS_WD="${WD}"
 export _CPAC_STATUS_TOKEN_FILE="${TOKEN_FILE}"
-SCRIPT_DIR="$(dirname "$0")"
-# shellcheck disable=SC1090
-"${SCRIPT_DIR}/regtest_full.py"
+"${CPAC_REGTEST_SCRIPT}"

--- a/src/cpac_slurm_testing/regression_run_scripts/regtest_full.sh
+++ b/src/cpac_slurm_testing/regression_run_scripts/regtest_full.sh
@@ -4,13 +4,14 @@
 
 set -x
 
-export _CPAC_STATUS_HOME_DIR="${HOME_DIR}"
+export _CPAC_STATUS_HOME_DIR="${HOME_DIR}/automatic_tests"
 export _CPAC_STATUS_IMAGE_NAME="${SHA#*:}"
-export _CPAC_STATUS_OUT="${HOME_DIR}/full/${_CPAC_STATUS_IMAGE_NAME}"
+export _CPAC_STATUS_OUT="${HOME_DIR}/${_CPAC_STATUS_IMAGE_NAME}/full"
 export _CPAC_STATUS_PRECONFIGS="default"
 export _CPAC_STATUS_SHA="${SHA}"
 export _CPAC_STATUS_DATA_SOURCE="Site-CBIC Site-SI HNU_1"
 export _CPAC_STATUS_WD="${WD}"
+export _CPAC_STATUS_TOKEN_FILE="${TOKEN_FILE}"
 SCRIPT_DIR="$(dirname "$0")"
 # shellcheck disable=SC1090
-source "${TOKEN_FILE}" && "${SCRIPT_DIR}/regtest_full.py"
+"${SCRIPT_DIR}/regtest_full.py"

--- a/src/cpac_slurm_testing/regression_run_scripts/regtest_full.sh
+++ b/src/cpac_slurm_testing/regression_run_scripts/regtest_full.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/bash
 
-# Required environment variables: $COMPARISON_PATH, $GH_AVAILABLE, $HOME_DIR, $IMAGE, $OWNER, $PATH, $PUSH_LOGS, $REPO, $SHA, $SLURM_TESTING_REPO, $SLURM_TESTING_BRANCH, $TOKEN_FILE
+# Required environment variables: $HOME_DIR, $SHA, $TESTING_PATHS, $TOKEN_FILE
 
 set -x
 
-export _CPAC_STATUS_HOME_DIR="${HOME_DIR}/automatic_tests"
+export _CPAC_STATUS_HOME_DIR="${HOME_DIR}"
 export _CPAC_STATUS_IMAGE_NAME="${SHA#*:}"
 export _CPAC_STATUS_OUT="${HOME_DIR}/automatic_tests/full/${_CPAC_STATUS_IMAGE_NAME}"
 export _CPAC_STATUS_PRECONFIGS="default"
 export _CPAC_STATUS_SHA="${SHA}"
 export _CPAC_STATUS_DATA_SOURCE="Site-CBIC Site-SI HNU_1"
-export _CPAC_STATUS_WD="${WD}"
+export _CPAC_STATUS_WD="${TESTING_PATHS}"
 export _CPAC_STATUS_TOKEN_FILE="${TOKEN_FILE}"
 "${CPAC_REGTEST_SCRIPT}"

--- a/src/cpac_slurm_testing/regression_run_scripts/regtest_full.sh
+++ b/src/cpac_slurm_testing/regression_run_scripts/regtest_full.sh
@@ -6,7 +6,7 @@ set -x
 
 export _CPAC_STATUS_HOME_DIR="${HOME_DIR}/automatic_tests"
 export _CPAC_STATUS_IMAGE_NAME="${SHA#*:}"
-export _CPAC_STATUS_OUT="${HOME_DIR}/${_CPAC_STATUS_IMAGE_NAME}/full"
+export _CPAC_STATUS_OUT="${HOME_DIR}/automatic_tests/full/${_CPAC_STATUS_IMAGE_NAME}"
 export _CPAC_STATUS_PRECONFIGS="default"
 export _CPAC_STATUS_SHA="${SHA}"
 export _CPAC_STATUS_DATA_SOURCE="Site-CBIC Site-SI HNU_1"

--- a/src/cpac_slurm_testing/regression_run_scripts/regtest_lite.sh
+++ b/src/cpac_slurm_testing/regression_run_scripts/regtest_lite.sh
@@ -24,7 +24,7 @@ for PIPELINE in ${PRECONFIGS}; do
 
         for SUBJECT_PATH in "${DATAPATH}"/sub-*; do
             SUBJECT=$(basename "${SUBJECT_PATH}")
-            cpac-slurm-status add --wd="${OUT}" --data_source="${DATA}" --preconfig="${PIPELINE}" --subject="${SUBJECT}"
+            cpac-slurm-status lite add --wd="${OUT}" --data_source="${DATA}" --preconfig="${PIPELINE}" --subject="${SUBJECT}"
 
         done
     done

--- a/src/cpac_slurm_testing/regression_run_scripts/regtest_lite.sh
+++ b/src/cpac_slurm_testing/regression_run_scripts/regtest_lite.sh
@@ -9,7 +9,7 @@ source "${TOKEN_FILE}"
 
 IMAGE_NAME="${SHA#*:}"
 DATA_DIR="${HOME_DIR}/DATA/reg_5mm_pack"
-OUT="${HOME_DIR}/automatic_tests/${IMAGE_NAME}/lite"
+OUT="${HOME_DIR}/automatic_tests/lite/${IMAGE_NAME}"
 # IMAGE="${IMAGE_NAME}.sif"
 PRECONFIGS="default"
 DATA_SOURCE="Site-CBIC Site-SI HNU_1"

--- a/src/cpac_slurm_testing/regression_run_scripts/regtest_lite.sh
+++ b/src/cpac_slurm_testing/regression_run_scripts/regtest_lite.sh
@@ -9,7 +9,7 @@ source "${TOKEN_FILE}"
 
 IMAGE_NAME="${SHA#*:}"
 DATA_DIR="${HOME_DIR}/DATA/reg_5mm_pack"
-OUT="${HOME_DIR}/lite/${IMAGE_NAME}"
+OUT="${HOME_DIR}/automatic_tests/${IMAGE_NAME}/lite"
 # IMAGE="${IMAGE_NAME}.sif"
 PRECONFIGS="default"
 DATA_SOURCE="Site-CBIC Site-SI HNU_1"

--- a/src/cpac_slurm_testing/status/_global.py
+++ b/src/cpac_slurm_testing/status/_global.py
@@ -5,9 +5,8 @@ import os
 from pathlib import Path
 from typing import Literal, Optional, TypeAlias
 
-from cpac_slurm_testing.utils._typing import PathStr, SCOPES
+from cpac_slurm_testing.utils._typing import PathStr, Scope, SCOPES
 
-CommandType: TypeAlias = Literal["full_run", "lite_run"]
 HOME_DIR = Path(os.environ.get("HOME_DIR", os.path.expanduser("~")))
 JobState: TypeAlias = Literal[
     "COMPLETED",
@@ -32,9 +31,11 @@ JOB_STATES: dict[JobState, _State] = {
     "SUSPENDED": "pending",
 }
 LOG_FORMAT = "%(asctime)s: %(levelname)s: %(pathname)s: %(funcName)s:\n\t%(message)s\n"
-TEMPLATES = {
-    key: files("cpac_slurm_testing.templates").joinpath(f"{key}.ftxt").read_text()
-    for key in [f"{scope}_run" for scope in SCOPES]
+TEMPLATES: dict[Scope, str] = {
+    scope: files("cpac_slurm_testing.templates")
+    .joinpath(f"{scope}_run.ftxt")
+    .read_text()
+    for scope in SCOPES
 }
 SBATCH_START: list[str] = ["sbatch", "-p", "RM-shared", "--ntasks=4"]
 

--- a/src/cpac_slurm_testing/status/cli.py
+++ b/src/cpac_slurm_testing/status/cli.py
@@ -2,6 +2,7 @@
 from argparse import ArgumentParser, Namespace, RawDescriptionHelpFormatter
 from logging import Logger
 import os
+from types import SimpleNamespace
 
 from cpac_slurm_testing import __version__
 from cpac_slurm_testing.launch import launch, LaunchParameters
@@ -52,7 +53,7 @@ class SlurmTestingNamespace(Namespace):
                 raise LookupError(msg)
         return value
 
-    def __init__(self, original: Namespace) -> None:
+    def __init__(self, original: Namespace | SimpleNamespace) -> None:
         """Initialize Namespace."""
         super().__init__(
             **{
@@ -63,7 +64,7 @@ class SlurmTestingNamespace(Namespace):
         if not hasattr(self, "dry_run"):
             self.dry_run: bool = False
             """Skip actually running commands?"""
-        self.testing_paths = TestingPaths(self.wd)
+        self.testing_paths = TestingPaths(getattr(self, "wd", os.getcwd()))
 
 
 def _parser_arg_helpstring(arg: str) -> str:

--- a/src/cpac_slurm_testing/status/cli.py
+++ b/src/cpac_slurm_testing/status/cli.py
@@ -67,7 +67,7 @@ class SlurmTestingNamespace(Namespace):
             self.dry_run: bool = False
             """Skip actually running commands?"""
         self.testing_paths = TestingPaths(
-            scope=original.scope, wd=getattr(self, "wd", os.getcwd())
+            scope=self.scope, wd=getattr(self, "wd", os.getcwd())
         )
 
 

--- a/src/cpac_slurm_testing/status/cli.py
+++ b/src/cpac_slurm_testing/status/cli.py
@@ -8,6 +8,7 @@ from cpac_slurm_testing import __version__
 from cpac_slurm_testing.launch import launch, LaunchParameters
 from cpac_slurm_testing.status._global import get_logger
 from cpac_slurm_testing.status.status import TestingPaths, TotalStatus
+from cpac_slurm_testing.utils import SCOPES
 
 LOGGER: Logger = get_logger(name=__name__)
 
@@ -64,7 +65,9 @@ class SlurmTestingNamespace(Namespace):
         if not hasattr(self, "dry_run"):
             self.dry_run: bool = False
             """Skip actually running commands?"""
-        self.testing_paths = TestingPaths(getattr(self, "wd", os.getcwd()))
+        self.testing_paths = TestingPaths(
+            scope=original.scope, wd=getattr(self, "wd", os.getcwd())
+        )
 
 
 def _parser_arg_helpstring(arg: str) -> str:
@@ -75,6 +78,12 @@ def _parser_arg_helpstring(arg: str) -> str:
 def _parser() -> tuple[ArgumentParser, dict[str, ArgumentParser]]:
     """Create a parser to parse commandline args."""
     base_parser = ArgumentParser(add_help=False)
+    base_parser.add_argument(
+        dest="scope",
+        choices=SCOPES,
+        default="lite",
+        help="lite (downsampled) or full (raw)?",
+    )
     base_parser.add_argument(
         "--working_directory",
         "--workdir",
@@ -148,7 +157,9 @@ def main() -> None:
             )
         )
     else:
-        status = TotalStatus(testing_paths=args.testing_paths, dry_run=args.dry_run)
+        status = TotalStatus(
+            testing_paths=args.testing_paths, scope=args.scope, dry_run=args.dry_run
+        )
         if args.command in ["add", "finalize"]:
             status.update(args)
         elif args.command == "check":

--- a/src/cpac_slurm_testing/status/cli.py
+++ b/src/cpac_slurm_testing/status/cli.py
@@ -67,7 +67,7 @@ class SlurmTestingNamespace(Namespace):
             self.dry_run: bool = False
             """Skip actually running commands?"""
         self.testing_paths = TestingPaths(
-            scope=original.data_scope, wd=getattr(self, "wd", os.getcwd())
+            scope=original.scope, wd=getattr(self, "wd", os.getcwd())
         )
 
 

--- a/src/cpac_slurm_testing/status/cli.py
+++ b/src/cpac_slurm_testing/status/cli.py
@@ -8,7 +8,7 @@ from cpac_slurm_testing import __version__
 from cpac_slurm_testing.launch import launch, LaunchParameters
 from cpac_slurm_testing.status._global import get_logger
 from cpac_slurm_testing.status.status import TestingPaths, TotalStatus
-from cpac_slurm_testing.utils import SCOPES
+from cpac_slurm_testing.utils import Scope, SCOPES
 
 LOGGER: Logger = get_logger(name=__name__)
 
@@ -56,6 +56,7 @@ class SlurmTestingNamespace(Namespace):
 
     def __init__(self, original: Namespace | SimpleNamespace) -> None:
         """Initialize Namespace."""
+        self.scope: Scope
         super().__init__(
             **{
                 key: value if value else self._env_fallback(key)

--- a/src/cpac_slurm_testing/status/cli.py
+++ b/src/cpac_slurm_testing/status/cli.py
@@ -66,7 +66,7 @@ class SlurmTestingNamespace(Namespace):
             self.dry_run: bool = False
             """Skip actually running commands?"""
         self.testing_paths = TestingPaths(
-            scope=original.scope, wd=getattr(self, "wd", os.getcwd())
+            scope=original.data_scope, wd=getattr(self, "wd", os.getcwd())
         )
 
 
@@ -78,12 +78,6 @@ def _parser_arg_helpstring(arg: str) -> str:
 def _parser() -> tuple[ArgumentParser, dict[str, ArgumentParser]]:
     """Create a parser to parse commandline args."""
     base_parser = ArgumentParser(add_help=False)
-    base_parser.add_argument(
-        dest="scope",
-        choices=SCOPES,
-        default="lite",
-        help="lite (downsampled) or full (raw)?",
-    )
     base_parser.add_argument(
         "--working_directory",
         "--workdir",
@@ -101,6 +95,11 @@ def _parser() -> tuple[ArgumentParser, dict[str, ArgumentParser]]:
         description=__doc__,
         formatter_class=RawDescriptionHelpFormatter,
         parents=[base_parser],
+    )
+    parser.add_argument(
+        "data_scope",
+        choices=SCOPES,
+        help="lite (downsampled) or full (raw)?",
     )
     update_parser = ArgumentParser(add_help=False)
     for arg in ["data-source", "preconfig", "subject"]:
@@ -148,7 +147,9 @@ def main() -> None:
     """Run the script from the commandline."""
     # Parse the arguments
     parser, _subparsers = _parser()
-    args = SlurmTestingNamespace(parser.parse_args())
+    _args = parser.parse_args()
+    _args.scope = _args.data_scope
+    args = SlurmTestingNamespace(_args)
     # Update the status
     if args.command == "launch":
         launch(

--- a/src/cpac_slurm_testing/status/status.py
+++ b/src/cpac_slurm_testing/status/status.py
@@ -313,7 +313,7 @@ class RunStatus:
             log_dir=self.log_dir,
             image=self.total.image("path"),
             image_name=self.total.image("name"),
-            output=self.out() / self.preconfig / self.data_source,
+            output=ExistingPath(self.out() / self.preconfig / self.data_source),
             pdsd=self.pdsd,
             pipeline=self.preconfig,
             pipeline_configs=str(

--- a/src/cpac_slurm_testing/status/status.py
+++ b/src/cpac_slurm_testing/status/status.py
@@ -308,7 +308,7 @@ class RunStatus:
             self.log_dir.mkdir(mode=0o777, exist_ok=True)
         return TEMPLATES[command_type].format(
             datapath=getattr(datapaths[scope](self.total.home_dir), self.data_source),
-            regdatapath=self.total.home_dir / "DATA/reg_5mm_pack",
+            regdatapath=datapaths[scope](self.total.home_dir).regdatapath,
             home_dir=self.total.home_dir,
             log_dir=self.log_dir,
             image=self.total.image("path"),

--- a/src/cpac_slurm_testing/status/status.py
+++ b/src/cpac_slurm_testing/status/status.py
@@ -96,7 +96,7 @@ def _set_working_directory(
         _logger = LOGGER.warning
         _log_msg = ["`wd` was not provided and `$REGTEST_LOG_DIR` is not set."]
     if wd:
-        wd = _set_intermediate_directory(coerce_to_Path(wd).absolute(), scope)
+        wd = coerce_to_Path(wd).absolute()
     else:
         from datetime import datetime
         from time import localtime, strftime

--- a/src/cpac_slurm_testing/status/status.py
+++ b/src/cpac_slurm_testing/status/status.py
@@ -538,7 +538,7 @@ class TotalStatus:
 
     def out(self) -> Path:
         """Return the path to the output directory."""
-        return ExistingPath(self.home_dir / self.scope / self.image("name"))
+        return ExistingPath(self.home_dir / self.image("name") / self.scope)
 
     def check(self: "TotalStatus", args: Namespace) -> None:
         """Check a run's status."""

--- a/src/cpac_slurm_testing/status/status.py
+++ b/src/cpac_slurm_testing/status/status.py
@@ -417,7 +417,9 @@ class TotalStatus:
 
     def _cpac_image(self, name: str) -> CpacImage:
         """Create a C-PAC Image."""
-        return CpacImage(name, self.home_dir)
+        if name:
+            return CpacImage(name, self.home_dir)
+        return CpacImage(name, Path())
 
     @property
     def failure(self) -> Fraction:

--- a/src/cpac_slurm_testing/status/status.py
+++ b/src/cpac_slurm_testing/status/status.py
@@ -550,7 +550,7 @@ class TotalStatus:
 
     def out(self) -> Path:
         """Return the path to the output directory."""
-        return ExistingPath(self.home_dir / self.image("name") / self.scope)
+        return ExistingPath(self.home_dir / self.scope / self.image("name"))
 
     def check(self: "TotalStatus", args: Namespace) -> None:
         """Check a run's status."""

--- a/src/cpac_slurm_testing/status/status.py
+++ b/src/cpac_slurm_testing/status/status.py
@@ -473,9 +473,6 @@ class TotalStatus:
         """C-PAC image."""
 
         if git_remote:  # We're initializing a new TotalStatus, not loading existing one
-            self.image = (
-                self._cpac_image(image) if image is not None else self._cpac_image("")
-            )
             self.owner: str = git_remote.owner
             """Owner of repository on GitHub."""
             self.repo: str = git_remote.repo
@@ -486,6 +483,10 @@ class TotalStatus:
             """GitHub PAT."""
             self.home_dir: Path = coerce_to_Path(home_dir)
             """Home directory."""
+            self.image = (
+                self._cpac_image(image) if image is not None else self._cpac_image("")
+            )
+            """C-PAC image."""
         self.runs: dict[tuple[str, str, str], RunStatus] = {}
         """Dictionary like `{(datasource, preconfig, subject): run}` of runs with individual statuses."""
         self.load()

--- a/src/cpac_slurm_testing/status/status.py
+++ b/src/cpac_slurm_testing/status/status.py
@@ -542,7 +542,9 @@ class TotalStatus:
 
     def out(self) -> Path:
         """Return the path to the output directory."""
-        return ExistingPath(self.home_dir / self.scope / self.image.name)
+        return ExistingPath(
+            self.home_dir / "automatic_tests" / self.scope / self.image.name
+        )
 
     def check(self: "TotalStatus", args: Namespace) -> None:
         """Check a run's status."""

--- a/src/cpac_slurm_testing/status/status.py
+++ b/src/cpac_slurm_testing/status/status.py
@@ -307,9 +307,7 @@ class RunStatus:
         if not self.log_dir.exists():
             self.log_dir.mkdir(mode=0o777, exist_ok=True)
         return TEMPLATES[command_type].format(
-            datapath=getattr(
-                datapaths[scope](self.total.home_dir), self.data_source.lower()
-            ),
+            datapath=getattr(datapaths[scope](self.total.home_dir), self.data_source),
             regdatapath=self.total.home_dir / "DATA/reg_5mm_pack",
             home_dir=self.total.home_dir,
             log_dir=self.log_dir,
@@ -547,11 +545,12 @@ class TotalStatus:
         """Return the image name or path."""
         if name_or_path == "name":
             return self._image
-        return Path.cwd() / f"{self._image}.sif"
+        image_dir = ExistingPath(self.home_dir / self.image("name"))
+        return image_dir / f"{self._image}.sif"
 
     def out(self) -> Path:
         """Return the path to the output directory."""
-        return ExistingPath(self.home_dir / self.scope / self.image("name"))
+        return ExistingPath(self.home_dir / self.image("name") / self.scope)
 
     def check(self: "TotalStatus", args: Namespace) -> None:
         """Check a run's status."""

--- a/src/cpac_slurm_testing/status/status.py
+++ b/src/cpac_slurm_testing/status/status.py
@@ -68,7 +68,9 @@ class CpacImage:
     def path(self) -> Path:
         """Path to image."""
         if self:
-            image_dir = ExistingPath(self.home_dir / self.name)
+            image_dir = ExistingPath(
+                self.home_dir / "automatic_tests" / "images" / self.name
+            )
             return image_dir / f"{self.name}.sif"
         msg = "C-PAC image not defined."
         raise FileNotFoundError(msg)

--- a/src/cpac_slurm_testing/status/status.py
+++ b/src/cpac_slurm_testing/status/status.py
@@ -721,10 +721,7 @@ class TotalStatus:
                     "sha",
                     "testing_paths",
                 ]:
-                    if hasattr(status, attr):
-                        setattr(self, attr, getattr(status, attr))
-                    # elif attr == "github_token":
-                    #     breakpoint()
+                    setattr(self, attr, getattr(status, attr))
                 if self.runs:
                     for run in self.runs.values():
                         status += run
@@ -810,8 +807,6 @@ class TotalStatus:
 
     def __iadd__(self, other: RunStatus) -> "TotalStatus":
         """Add a run to the total status."""
-        return self + other
-        breakpoint()
         self.runs.update({other.key: other})
         self.write()
         return self

--- a/src/cpac_slurm_testing/status/status.py
+++ b/src/cpac_slurm_testing/status/status.py
@@ -101,7 +101,7 @@ def _set_working_directory(
         from datetime import datetime
         from time import localtime, strftime
 
-        wd = ExistingPath(
+        wd = (
             Path.cwd().absolute()
             / scope
             / "".join(
@@ -111,6 +111,7 @@ def _set_working_directory(
                 ]
             )
         )
+    wd = ExistingPath(wd)
     os.chdir(str(wd))
     _log_msg = ["Set working directory to %s", str(wd)]
     _logpath = ExistingPath(wd / "logs")

--- a/src/cpac_slurm_testing/status/status.py
+++ b/src/cpac_slurm_testing/status/status.py
@@ -135,6 +135,7 @@ class TestingPaths:
         self._log_dir: Path
         self._wd: Path
         self._wd, self._log_dir = _set_working_directory(scope, wd)
+        self.scope = scope
 
     @property
     def log_dir(self) -> Path:
@@ -161,7 +162,7 @@ class TestingPaths:
 
     def __repr__(self) -> str:
         """Return reproducible TestingPaths."""
-        return f"TestingPaths(Path('{self.wd}'))"
+        return f"TestingPaths('{self.scope}', Path('{self.wd}'))"
 
     def __str__(self) -> str:
         """Return a string representation of TestingPaths."""

--- a/src/cpac_slurm_testing/status/status.py
+++ b/src/cpac_slurm_testing/status/status.py
@@ -522,7 +522,7 @@ class TotalStatus:
         for run in self.runs.values():
             if run._command_file:
                 unlink(run._command_file)  # remove launch script
-        unlink(self.image.path)  # remove Apptainer image
+        # unlink(self.image.path)  # remove Apptainer image
         # unlink(self.path)  # remove launch pickle
 
     @property

--- a/src/cpac_slurm_testing/status/status.py
+++ b/src/cpac_slurm_testing/status/status.py
@@ -784,7 +784,8 @@ class TotalStatus:
             status=getattr(args, "status", "pending"),
             _total=self,
         )
-        run.launch("lite_run")
+        command_type = cast(CommandType, f"{args.scope}_run")
+        run.launch(command_type)
         self += run
 
     def write(self) -> None:

--- a/src/cpac_slurm_testing/status/status.py
+++ b/src/cpac_slurm_testing/status/status.py
@@ -538,7 +538,7 @@ class TotalStatus:
 
     def out(self) -> Path:
         """Return the path to the output directory."""
-        return ExistingPath(self.home_dir / self.image("name") / self.scope)
+        return ExistingPath(self.home_dir / self.scope / self.image("name"))
 
     def check(self: "TotalStatus", args: Namespace) -> None:
         """Check a run's status."""

--- a/src/cpac_slurm_testing/status/status.py
+++ b/src/cpac_slurm_testing/status/status.py
@@ -36,7 +36,6 @@ from cpac_slurm_testing.correlation.correlation import correlate, init_branch
 from cpac_slurm_testing.git_remote import GitRemoteInfo
 from cpac_slurm_testing.status._global import (
     _State,
-    CommandType,
     get_logger,
     JOB_STATES,
     JobState,
@@ -301,12 +300,12 @@ class RunStatus:
         """log directory"""
         self._total += self
 
-    def command(self, command_type: str, scope: Scope = "lite") -> str:
-        """Return a command string for a given command_type."""
+    def command(self, scope: Scope = "lite") -> str:
+        """Return a command string for a given scope."""
         assert self._total is not None
         if not self.log_dir.exists():
             self.log_dir.mkdir(mode=0o777, exist_ok=True)
-        return TEMPLATES[command_type].format(
+        return TEMPLATES[scope].format(
             datapath=getattr(datapaths[scope](self.total.home_dir), self.data_source),
             regdatapath=datapaths[scope](self.total.home_dir).regdatapath,
             home_dir=self.total.home_dir,
@@ -337,22 +336,11 @@ class RunStatus:
         """Return a unique key for each preconfig × data_source × subject."""  # noqa: RUF002
         return self.data_source, self.preconfig, self.subject
 
-    def launch(self, command_type: CommandType) -> None:
+    def launch(self, scope: Scope) -> None:
         """Launch a SLURM job and set its job ID."""
-        _command_types: list[str] = eval(
-            str(CommandType).replace(
-                str(
-                    CommandType.__origin__  # type: ignore[attr-defined]
-                ),
-                "",
-            )
-        )
-        if command_type not in _command_types:
-            msg: str = f"{command_type} not in {_command_types}"
-            raise KeyError(msg)
         with NamedTemporaryFile(mode="w", encoding="utf8", delete=False) as _f:
             self._command_file = Path(_f.name)
-            _f.write(self.command(command_type))
+            _f.write(self.command(scope))
             _f.close()
             with open(_f.name, "r", encoding="utf8") as _command_file:
                 LOGGER.info(
@@ -784,8 +772,7 @@ class TotalStatus:
             status=getattr(args, "status", "pending"),
             _total=self,
         )
-        command_type = cast(CommandType, f"{args.scope}_run")
-        run.launch(command_type)
+        run.launch(args.scope)
         self += run
 
     def write(self) -> None:

--- a/src/cpac_slurm_testing/status/status.py
+++ b/src/cpac_slurm_testing/status/status.py
@@ -43,7 +43,7 @@ from cpac_slurm_testing.status._global import (
     SBATCH_START,
     TEMPLATES,
 )
-from cpac_slurm_testing.utils import coerce_to_Path, unlink
+from cpac_slurm_testing.utils import coerce_to_Path, ExistingPath, unlink
 from cpac_slurm_testing.utils._typing import Scope
 from cpac_slurm_testing.utils.datapaths import datapaths
 
@@ -51,7 +51,7 @@ LOGGER: Logger = get_logger(name=__name__)
 
 
 def _set_intermediate_directory(
-    directory: Path | str, intermediate: str, mkdir: bool = True
+    directory: Path | str, intermediate: Scope, mkdir: bool = True
 ) -> Path:
     """Set directory between user and image.
 
@@ -64,12 +64,14 @@ def _set_intermediate_directory(
     """
     _parts: list[str] = str(directory).split("/")
     path = Path("/".join([*_parts[:-2], intermediate, _parts[-1]]))
-    if mkdir and not path.exists():
-        os.makedirs(str(path), exist_ok=True)
+    if mkdir:
+        path = ExistingPath(path)
     return path
 
 
-def _set_working_directory(wd: Optional[Path | str] = None) -> tuple[Path, Path]:
+def _set_working_directory(
+    scope: Scope, wd: Optional[Path | str] = None
+) -> tuple[Path, Path]:
     """Set working directory.
 
     Priority order:
@@ -95,14 +97,14 @@ def _set_working_directory(wd: Optional[Path | str] = None) -> tuple[Path, Path]
         _logger = LOGGER.warning
         _log_msg = ["`wd` was not provided and `$REGTEST_LOG_DIR` is not set."]
     if wd:
-        wd = _set_intermediate_directory(coerce_to_Path(wd).absolute(), "lite")
+        wd = _set_intermediate_directory(coerce_to_Path(wd).absolute(), scope)
     else:
         from datetime import datetime
         from time import localtime, strftime
 
-        wd = (
+        wd = ExistingPath(
             Path.cwd().absolute()
-            / "lite"
+            / scope
             / "".join(
                 [
                     datetime.now().strftime("%Y%m%d%H%M%S.%f%Z"),
@@ -110,26 +112,23 @@ def _set_working_directory(wd: Optional[Path | str] = None) -> tuple[Path, Path]
                 ]
             )
         )
-        for parent in reversed(wd.parents):
-            parent.mkdir(mode=0o777, exist_ok=True)
-        wd.mkdir(mode=0o777, exist_ok=True)
     os.chdir(str(wd))
     _log_msg = ["Set working directory to %s", str(wd)]
-    _logpath: Path = _set_intermediate_directory(wd, "logs")
+    _logpath = ExistingPath(wd / "logs")
     LOGGER = get_logger(name=__name__, filename=f"{_logpath}/{filename}", force=True)
     _logger = LOGGER.info
     _logger(*_log_msg)  # log info or warning as appropriate
-    return Path(wd), Path(_logpath)
+    return wd, _logpath
 
 
 class TestingPaths:
     """Working and logging path management."""
 
-    def __init__(self, wd: Optional[Path | str] = None) -> None:
+    def __init__(self, scope: Scope = "lite", wd: Optional[Path | str] = None) -> None:
         """Initialize TestingPaths."""
         self._log_dir: Path
         self._wd: Path
-        self._wd, self._log_dir = _set_working_directory(wd)
+        self._wd, self._log_dir = _set_working_directory(scope, wd)
 
     @property
     def log_dir(self) -> Path:
@@ -316,7 +315,7 @@ class RunStatus:
             log_dir=self.log_dir,
             image=self.total.image("path"),
             image_name=self.total.image("name"),
-            output=self.out(scope) / self.preconfig / self.data_source,
+            output=self.out() / self.preconfig / self.data_source,
             pdsd=self.pdsd,
             pipeline=self.preconfig,
             pipeline_configs=str(
@@ -381,9 +380,9 @@ class RunStatus:
                 )
             LOGGER.info("%s = %s", self.job_id, " ".join(command))
 
-    def out(self, lite_or_full: Literal["full", "lite"]) -> Path:
+    def out(self) -> Path:
         """Return the path to the output directory."""
-        return self.total.out(lite_or_full)
+        return self.total.out()
 
     @property
     def job_status(self) -> str:
@@ -445,9 +444,10 @@ class TotalStatus:
 
     successes.__doc__ = success.__doc__
 
-    def __init__(  # noqa: PLR0913
+    def __init__(  # noqa: PLR0913,PLR0915
         self,
         testing_paths: Path | str | TestingPaths,
+        scope: Scope = "lite",
         runs: Optional[list[RunStatus]] = None,
         home_dir: Optional[Path | str] = None,
         image: Optional[str] = None,
@@ -457,10 +457,11 @@ class TotalStatus:
         if isinstance(testing_paths, str):
             testing_paths = Path(testing_paths)
         if isinstance(testing_paths, Path):
-            testing_paths = TestingPaths(testing_paths)
+            testing_paths = TestingPaths(scope=scope, wd=testing_paths)
         if not isinstance(testing_paths, TestingPaths):
             msg: str = f"{testing_paths} is not an instance of {TestingPaths}"
             raise TypeError(msg)
+        self.scope: Scope = scope
         self.testing_paths: TestingPaths = testing_paths
         self.dry_run: bool = dry_run
         """Skip actually running commands?"""
@@ -548,9 +549,9 @@ class TotalStatus:
             return self._image
         return Path.cwd() / f"{self._image}.sif"
 
-    def out(self, lite_or_full: Literal["full", "lite"]) -> Path:
+    def out(self) -> Path:
         """Return the path to the output directory."""
-        return self.home_dir / lite_or_full / self.image("name")
+        return ExistingPath(self.home_dir / self.scope / self.image("name"))
 
     def check(self: "TotalStatus", args: Namespace) -> None:
         """Check a run's status."""
@@ -580,6 +581,7 @@ class TotalStatus:
             f"--error={self.testing_paths.log_dir}/check_{timestamp}.err.log",
             f"--begin={time}",
             "cpac-slurm-status",
+            self.scope,
             "check-all",
             f'--wd="{Path.cwd()}"',
         ]
@@ -596,7 +598,7 @@ class TotalStatus:
 
     def correlate(self, n_cpus: int = 4) -> None:
         """Launch correlation process."""
-        this_pipeline: Path = self.out("lite")
+        this_pipeline: Path = self.out()
         latest_ref: Path = this_pipeline.parent / self.latest
         correlations_dir: Path | str = this_pipeline / "correlations"
         assert isinstance(correlations_dir, Path)
@@ -759,7 +761,7 @@ class TotalStatus:
             state=self.status,
             target_url=target_url,
             description=self.description,
-            context="lite regression test",
+            context=f"{self.scope} regression test",
         )
 
     @property
@@ -809,6 +811,7 @@ class TotalStatus:
         runs.update({other.key: other})
         return TotalStatus(
             testing_paths=self.testing_paths,
+            scope=self.scope,
             runs=list(runs.values()),
             image=self._image,
             dry_run=self.dry_run,
@@ -824,7 +827,7 @@ class TotalStatus:
         """Return reproducible string for TotalStatus."""
         image_info = (f", image='{self.image('name')}'") if self._image else ""
         return (
-            f"TotalStatus(testing_paths={self.testing_paths!r}, runs={self.runs}"
+            f"TotalStatus(testing_paths={self.testing_paths!r}, scope={self.scope}, runs={self.runs}"
             f"{image_info}, dry_run={self.dry_run})"
         )
 

--- a/src/cpac_slurm_testing/status/status.py
+++ b/src/cpac_slurm_testing/status/status.py
@@ -49,23 +49,29 @@ from cpac_slurm_testing.utils.datapaths import datapaths
 LOGGER: Logger = get_logger(name=__name__)
 
 
-def _set_intermediate_directory(
-    directory: Path | str, intermediate: Scope, mkdir: bool = True
-) -> Path:
-    """Set directory between user and image.
+@dataclass
+class CpacImage:
+    """Consistently access C-PAC image name and path."""
 
-    Examples
-    --------
-    >>> str(_set_intermediate_directory('/home/user/full/image', 'lite', False))
-    '/home/user/lite/image'
-    >>> str(_set_intermediate_directory('/home/user/full/image', 'logs', False))
-    '/home/user/logs/image'
-    """
-    _parts: list[str] = str(directory).split("/")
-    path = Path("/".join([*_parts[:-2], intermediate, _parts[-1]]))
-    if mkdir:
-        path = ExistingPath(path)
-    return path
+    name: str
+    home_dir: Path
+
+    def __bool__(self) -> bool:
+        """Is the C-PAC image defined?"""  # noqa: D400
+        return bool(self.name)
+
+    def __str__(self) -> str:
+        """Return string representation of C-PAC image."""
+        return self.name
+
+    @property
+    def path(self) -> Path:
+        """Path to image."""
+        if self:
+            image_dir = ExistingPath(self.home_dir / self.name)
+            return image_dir / f"{self.name}.sif"
+        msg = "C-PAC image not defined."
+        raise FileNotFoundError(msg)
 
 
 def _set_working_directory(
@@ -311,8 +317,8 @@ class RunStatus:
             regdatapath=datapaths[scope](self.total.home_dir).regdatapath,
             home_dir=self.total.home_dir,
             log_dir=self.log_dir,
-            image=self.total.image("path"),
-            image_name=self.total.image("name"),
+            image=self.total.image.path,
+            image_name=self.total.image.name,
             output=ExistingPath(self.out() / self.preconfig / self.data_source),
             pdsd=self.pdsd,
             pipeline=self.preconfig,
@@ -409,6 +415,10 @@ class RunStatus:
 class TotalStatus:
     """Store the total status of all runs for the GitHub Check."""
 
+    def _cpac_image(self, name: str) -> CpacImage:
+        """Create a C-PAC Image."""
+        return CpacImage(name, self.home_dir)
+
     @property
     def failure(self) -> Fraction:
         """Return the fraction of runs that are failures."""
@@ -457,11 +467,13 @@ class TotalStatus:
             path = Path(f"{path.name}.dry")
         self.path: Path = path
         """Path to status data on disk."""
-        self._image: str = ""
-        """Name of image."""
+        self.image: CpacImage = self._cpac_image("")
+        """C-PAC image."""
 
         if git_remote:  # We're initializing a new TotalStatus, not loading existing one
-            self._image = image if image is not None else ""
+            self.image = (
+                self._cpac_image(image) if image is not None else self._cpac_image("")
+            )
             self.owner: str = git_remote.owner
             """Owner of repository on GitHub."""
             self.repo: str = git_remote.repo
@@ -482,7 +494,7 @@ class TotalStatus:
         for run in self.runs.values():
             run.total = self
         self.log()
-        if self.image():
+        if self.image:
             self.write()
         if initial_state == "idle":
             if self.status != "idle" and not self.dry_run:
@@ -504,7 +516,7 @@ class TotalStatus:
         for run in self.runs.values():
             if run._command_file:
                 unlink(run._command_file)  # remove launch script
-        unlink(self.image("path"))  # remove Apptainer image
+        unlink(self.image.path)  # remove Apptainer image
         # unlink(self.path)  # remove launch pickle
 
     @property
@@ -522,24 +534,9 @@ class TotalStatus:
         """Return a list of all unique subjects in a TotalStatus."""
         return list({subject for _, _, subject in self.runs.keys()})
 
-    @overload
-    def image(self, name_or_path: Literal["name"] = "name") -> str:
-        ...
-
-    @overload
-    def image(self, name_or_path: Literal["path"]) -> Path:
-        ...
-
-    def image(self, name_or_path: Literal["name", "path"] = "name") -> Path | str:
-        """Return the image name or path."""
-        if name_or_path == "name":
-            return self._image
-        image_dir = ExistingPath(self.home_dir / self.image("name"))
-        return image_dir / f"{self._image}.sif"
-
     def out(self) -> Path:
         """Return the path to the output directory."""
-        return ExistingPath(self.home_dir / self.scope / self.image("name"))
+        return ExistingPath(self.home_dir / self.scope / self.image.name)
 
     def check(self: "TotalStatus", args: Namespace) -> None:
         """Check a run's status."""
@@ -593,7 +590,7 @@ class TotalStatus:
         if not correlations_dir.exists():
             correlations_dir.mkdir(mode=0o777, exist_ok=True)
         correlations_dir = str(correlations_dir)
-        branch: str = cast(str, self.image("name"))
+        branch: str = self.image.name
         correlation_slurm_jobs: list[int] = []
         for data_source in self.datasources:
             for preconfig in self.preconfigs:
@@ -714,14 +711,17 @@ class TotalStatus:
                     "dry_run",
                     "github_token",
                     "home_dir",
-                    "_image",
+                    "image",
                     "owner",
                     "path",
                     "repo",
                     "sha",
                     "testing_paths",
                 ]:
-                    setattr(self, attr, getattr(status, attr))
+                    if hasattr(status, attr):
+                        setattr(self, attr, getattr(status, attr))
+                    # elif attr == "github_token":
+                    #     breakpoint()
                 if self.runs:
                     for run in self.runs.values():
                         status += run
@@ -801,19 +801,21 @@ class TotalStatus:
             testing_paths=self.testing_paths,
             scope=self.scope,
             runs=list(runs.values()),
-            image=self._image,
+            image=self.image.name,
             dry_run=self.dry_run,
         )
 
     def __iadd__(self, other: RunStatus) -> "TotalStatus":
         """Add a run to the total status."""
+        return self + other
+        breakpoint()
         self.runs.update({other.key: other})
         self.write()
         return self
 
     def __repr__(self) -> str:
         """Return reproducible string for TotalStatus."""
-        image_info = (f", image='{self.image('name')}'") if self._image else ""
+        image_info = (f", image='{self.image.name}'") if self.image else ""
         return (
             f"TotalStatus(testing_paths={self.testing_paths!r}, scope={self.scope}, runs={self.runs}"
             f"{image_info}, dry_run={self.dry_run})"
@@ -821,7 +823,7 @@ class TotalStatus:
 
     def __str__(self) -> str:
         """Return string representation of TotalStatus."""
-        image_info: list[str] = [f"{self.image('name')}"] if self._image else []
+        image_info: list[str] = [f"{self.image.name}"] if self.image else []
         return "\n".join(
             [
                 *image_info,

--- a/src/cpac_slurm_testing/templates/full_run.ftxt
+++ b/src/cpac_slurm_testing/templates/full_run.ftxt
@@ -1,0 +1,32 @@
+#!/usr/bin/bash
+#SBATCH -N 1
+#SBATCH -p RM-shared
+#SBATCH -t 10:00:00
+#SBATCH --ntasks=4
+#SBATCH -o {log_dir}/%x.out.log
+#SBATCH --error {log_dir}/%x.err.log
+#SBATCH -J {pdsd}-{image_name}-regfull
+
+set -x
+
+export APPTAINER_CACHEDIR={home_dir}/.apptainer/cache \
+       APPTAINER_LOCALCACHEDIR={home_dir}/.apptainer/tmp
+
+apptainer run \
+    --cleanenv \
+    -B {home_dir} \
+    -B {datapath}:/data \
+    -B {regdatapath}:/reg-data \
+    -B {output}:/outputs \
+    -B {pipeline_configs}:/pipeline_configs \
+    {image} /data /outputs participant \
+    --save_working_dir --skip_bids_validator \
+    --participant_label {subject} \
+    --n_cpus 3 --mem_gb 40
+
+if grep -q "CPAC run complete" {log_dir}/*.out.log
+then
+  exit 0  # Exit with success code
+else
+  exit 1  # Exit with failure code
+fi

--- a/src/cpac_slurm_testing/utils/__init__.py
+++ b/src/cpac_slurm_testing/utils/__init__.py
@@ -1,5 +1,5 @@
 """Utilities for C-PAC Slurm testing."""
-from ._typing import coerce_to_Path, PATH_OR_STR
+from ._typing import coerce_to_Path, PathStr
 from .utils import unlink
 
-__all__ = ["coerce_to_Path", "PATH_OR_STR", "unlink"]
+__all__ = ["coerce_to_Path", "PathStr", "unlink"]

--- a/src/cpac_slurm_testing/utils/__init__.py
+++ b/src/cpac_slurm_testing/utils/__init__.py
@@ -1,5 +1,5 @@
 """Utilities for C-PAC Slurm testing."""
-from ._typing import coerce_to_Path, PathStr
-from .utils import unlink
+from ._typing import coerce_to_Path, PathStr, Scope, SCOPES
+from .utils import ExistingPath, unlink
 
-__all__ = ["coerce_to_Path", "PathStr", "unlink"]
+__all__ = ["coerce_to_Path", "ExistingPath", "PathStr", "Scope", "SCOPES", "unlink"]

--- a/src/cpac_slurm_testing/utils/_typing.py
+++ b/src/cpac_slurm_testing/utils/_typing.py
@@ -1,11 +1,13 @@
 """Typing utilities."""
 from pathlib import Path
-from typing import Optional
+from typing import Literal, Optional, TypeAlias
 
-PATH_OR_STR = Path | str
+PathStr: TypeAlias = Path | str
+Scope: TypeAlias = Literal["full", "lite"]
+SCOPES = ["full", "lite"]
 
 
-def coerce_to_Path(path: Optional[PATH_OR_STR]) -> Path:
+def coerce_to_Path(path: Optional[PathStr]) -> Path:
     """Return a Path from a given path or string."""
     if isinstance(path, str):
         path = Path(path.strip("\"'"))
@@ -15,4 +17,4 @@ def coerce_to_Path(path: Optional[PATH_OR_STR]) -> Path:
     return path
 
 
-__all__ = ["coerce_to_Path", "PATH_OR_STR"]
+__all__ = ["coerce_to_Path", "PathStr"]

--- a/src/cpac_slurm_testing/utils/_typing.py
+++ b/src/cpac_slurm_testing/utils/_typing.py
@@ -4,7 +4,7 @@ from typing import Literal, Optional, TypeAlias
 
 PathStr: TypeAlias = Path | str
 Scope: TypeAlias = Literal["full", "lite"]
-SCOPES = ["full", "lite"]
+SCOPES: list[Scope] = ["full", "lite"]
 
 
 def coerce_to_Path(path: Optional[PathStr]) -> Path:

--- a/src/cpac_slurm_testing/utils/_typing.py
+++ b/src/cpac_slurm_testing/utils/_typing.py
@@ -17,4 +17,4 @@ def coerce_to_Path(path: Optional[PathStr]) -> Path:
     return path
 
 
-__all__ = ["coerce_to_Path", "PathStr"]
+__all__ = ["coerce_to_Path", "PathStr", "Scope", "SCOPES"]

--- a/src/cpac_slurm_testing/utils/datapaths.py
+++ b/src/cpac_slurm_testing/utils/datapaths.py
@@ -1,0 +1,62 @@
+"""Datapaths."""
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+SITES = ["CBIC", "HNU_1", "KKI", "oxford", "RBC", "SI"]
+
+
+@dataclass
+class RawData:
+    """Raw data for regression tests."""
+
+    root: Path
+    cbic: Path
+    hnu_1: Path
+    kki: Path
+    oxford: Path
+    rbc: Path
+    rodent: Path
+    si: Path
+
+
+class FullData(RawData):
+    """Full raw data."""
+
+    def __init__(self, home_dir: Optional[Path]) -> None:
+        """Initialize full raw data.
+
+        Parameters
+        ----------
+        home_dir
+            unused parameter, in place to match signature for lite data.
+        """
+        self.root = Path("/ocean/projects/med220004p/shared/data_raw/CPAC-Regression")
+        self.cbic = self.root / "HBN/MRI/Site-CBIC"
+        self.hnu_1 = self.root / "CORR/RawDataBIDS/HNU_1"
+        self.kki = self.root / "ADHD200/RawDataBIDS/KKI"
+        self.oxford = self.root / "nhp/oxford"
+        self.rodent = self.root / "rodent"
+        self.si = self.root / "HBN/MRI/Site-SI"
+
+
+class LiteData(RawData):
+    """Lite raw data."""
+
+    def __init__(self, home_dir: Path) -> None:
+        """Initialize lite raw data."""
+        self.root = home_dir / "DATA/reg_5mm_pack/data"
+        for site in SITES:
+            setattr(
+                self,
+                site.lower(),
+                self.root / (f"Site-{site}" if site in ["CBIC", "SI"] else site),
+            )
+
+
+datapaths = {"full": FullData, "lite": LiteData}
+
+
+def list_site_subjects(site_dir: Path) -> list[str]:
+    """List subjects in a site directory."""
+    return [path.name for path in site_dir.iterdir() if path.name.startswith("sub-")]

--- a/src/cpac_slurm_testing/utils/datapaths.py
+++ b/src/cpac_slurm_testing/utils/datapaths.py
@@ -1,7 +1,7 @@
 """Datapaths."""
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, Optional, overload
+from typing import Literal, Optional, overload, TypedDict
 
 from cpac_slurm_testing.utils._typing import Scope
 
@@ -24,6 +24,11 @@ class RawData:
     rbc: Path
     rodent: Path
     si: Path
+
+    @property
+    def regdatapath(self) -> Path:
+        """Return path for binding regdata."""
+        return getattr(self, "_regdatapath", self.root)
 
     @property
     def scope(self):
@@ -74,7 +79,8 @@ class LiteData(RawData):
 
     def __init__(self, home_dir: Path) -> None:
         """Initialize lite raw data."""
-        self.root = home_dir / "DATA/reg_5mm_pack/data"
+        self._regdatapath = home_dir / "DATA/reg_5mm_pack"
+        self.root = self.regdatapath / "data"
         for site in SITES:
             setattr(
                 self,
@@ -83,7 +89,14 @@ class LiteData(RawData):
             )
 
 
-datapaths = {"full": FullData, "lite": LiteData}
+class DataPaths(TypedDict):
+    """Typed dict to hold datapaths."""
+
+    full: type[FullData]
+    lite: type[LiteData]
+
+
+datapaths: DataPaths = {"full": FullData, "lite": LiteData}
 
 
 def list_site_subjects(site_dir: Path) -> list[str]:

--- a/src/cpac_slurm_testing/utils/datapaths.py
+++ b/src/cpac_slurm_testing/utils/datapaths.py
@@ -1,9 +1,15 @@
 """Datapaths."""
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Literal, Optional, overload
+
+from cpac_slurm_testing.utils._typing import Scope
 
 SITES = ["CBIC", "HNU_1", "KKI", "oxford", "RBC", "SI"]
+
+
+class RawDataNotFound(FileNotFoundError):
+    """Raw data path not defined for this scope."""
 
 
 @dataclass
@@ -18,6 +24,29 @@ class RawData:
     rbc: Path
     rodent: Path
     si: Path
+
+    @property
+    def scope(self):
+        """Get the testing scope of the RawData."""
+        return self.__class__.__name__.split("Data", 1)[0].lower()
+
+    @overload
+    def __getattr__(self, name: Literal["scope"]) -> Scope | Literal["raw"]:  # type: ignore  # pyright: ignore[reportOverlappingOverload]
+        ...
+
+    @overload
+    def __getattr__(self, name: str) -> Path:
+        ...
+
+    def __getattr__(self, name: str) -> Path | Scope | Literal["raw"]:
+        """Get a Path or raise an exception."""
+        if name in ["root", "scope"] or name.startswith("__"):
+            return object.__getattribute__(self, name)
+        name = name.lower()
+        if name in self.__dict__:
+            return object.__getattribute__(self, name)
+        msg = f"{name} not defined for {self.scope} data."
+        raise RawDataNotFound(msg)
 
 
 class FullData(RawData):

--- a/src/cpac_slurm_testing/utils/datapaths.py
+++ b/src/cpac_slurm_testing/utils/datapaths.py
@@ -30,7 +30,11 @@ class RawData:
     @property
     def regdatapath(self) -> Path:
         """Return path for binding regdata."""
-        return getattr(self, "_regdatapath", self.root)
+        if hasattr(self, "_regdatapath") and isinstance(self._regdatapath, Path):
+            return self._regdatapath
+        if isinstance(self.root, Path):
+            return self.root
+        raise RawDataNotFound
 
     @property
     def scope(self):
@@ -52,6 +56,7 @@ class RawData:
     ) -> GetRawData:
         """Get a Path or raise an exception."""
         if name in _NON_SITE_PROPERTIES or name.startswith("_"):
+            # breakpoint()
             return object.__getattribute__(self, name)
         name = name.lower()
         if name in self.__dict__:
@@ -60,6 +65,20 @@ class RawData:
             return default
         msg = f"{name} not defined for {self.scope} data."
         raise RawDataNotFound(msg)
+
+    def __str__(self) -> str:
+        """Return string representation of RawData."""
+        string = ""
+        for site in [
+            key
+            for key in dir(self)
+            if not key.startswith("_") and key not in _NON_SITE_PROPERTIES
+        ]:
+            try:
+                string += f"{site}: {getattr(self, site)}\n"
+            except RawDataNotFound:
+                string += f"{site}: Undefined\n"
+        return string
 
 
 class FullData(RawData):

--- a/src/cpac_slurm_testing/utils/datapaths.py
+++ b/src/cpac_slurm_testing/utils/datapaths.py
@@ -56,9 +56,10 @@ class RawData:
     ) -> GetRawData:
         """Get a Path or raise an exception."""
         if name in _NON_SITE_PROPERTIES or name.startswith("_"):
-            # breakpoint()
             return object.__getattribute__(self, name)
         name = name.lower()
+        if name.startswith("site-"):
+            name = name[5:]
         if name in self.__dict__:
             return object.__getattribute__(self, name)
         if default:

--- a/src/cpac_slurm_testing/utils/datapaths.py
+++ b/src/cpac_slurm_testing/utils/datapaths.py
@@ -6,6 +6,7 @@ from typing import Literal, Optional, overload, TypeAlias, TypedDict
 from cpac_slurm_testing.utils._typing import Scope
 
 SITES = ["CBIC", "HNU_1", "KKI", "oxford", "RBC", "SI"]
+_NON_SITE_PROPERTIES = ["regdatapath", "root", "scope"]
 GetRawData: TypeAlias = Path | Scope | Literal["raw"]
 
 
@@ -50,7 +51,7 @@ class RawData:
         self, name: str, default: Optional[GetRawData] = None
     ) -> GetRawData:
         """Get a Path or raise an exception."""
-        if name in ["root", "scope"] or name.startswith("_"):
+        if name in _NON_SITE_PROPERTIES or name.startswith("_"):
             return object.__getattribute__(self, name)
         name = name.lower()
         if name in self.__dict__:

--- a/src/cpac_slurm_testing/utils/datapaths.py
+++ b/src/cpac_slurm_testing/utils/datapaths.py
@@ -50,7 +50,7 @@ class RawData:
         self, name: str, default: Optional[GetRawData] = None
     ) -> GetRawData:
         """Get a Path or raise an exception."""
-        if name in ["root", "scope"] or name.startswith("__"):
+        if name in ["root", "scope"] or name.startswith("_"):
             return object.__getattribute__(self, name)
         name = name.lower()
         if name in self.__dict__:

--- a/src/cpac_slurm_testing/utils/datapaths.py
+++ b/src/cpac_slurm_testing/utils/datapaths.py
@@ -1,11 +1,12 @@
 """Datapaths."""
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, Optional, overload, TypedDict
+from typing import Literal, Optional, overload, TypeAlias, TypedDict
 
 from cpac_slurm_testing.utils._typing import Scope
 
 SITES = ["CBIC", "HNU_1", "KKI", "oxford", "RBC", "SI"]
+GetRawData: TypeAlias = Path | Scope | Literal["raw"]
 
 
 class RawDataNotFound(FileNotFoundError):
@@ -36,20 +37,26 @@ class RawData:
         return self.__class__.__name__.split("Data", 1)[0].lower()
 
     @overload
-    def __getattr__(self, name: Literal["scope"]) -> Scope | Literal["raw"]:  # type: ignore  # pyright: ignore[reportOverlappingOverload]
+    def __getattr__(  # type: ignore  # pyright: ignore[reportOverlappingOverload]
+        self, name: Literal["scope"], default: Optional[GetRawData] = None
+    ) -> Scope | Literal["raw"]:
         ...
 
     @overload
-    def __getattr__(self, name: str) -> Path:
+    def __getattr__(self, name: str, default: Optional[GetRawData] = None) -> Path:
         ...
 
-    def __getattr__(self, name: str) -> Path | Scope | Literal["raw"]:
+    def __getattr__(
+        self, name: str, default: Optional[GetRawData] = None
+    ) -> GetRawData:
         """Get a Path or raise an exception."""
         if name in ["root", "scope"] or name.startswith("__"):
             return object.__getattribute__(self, name)
         name = name.lower()
         if name in self.__dict__:
             return object.__getattribute__(self, name)
+        if default:
+            return default
         msg = f"{name} not defined for {self.scope} data."
         raise RawDataNotFound(msg)
 

--- a/src/cpac_slurm_testing/utils/utils.py
+++ b/src/cpac_slurm_testing/utils/utils.py
@@ -2,10 +2,10 @@
 from shutil import rmtree
 from typing import Literal
 
-from cpac_slurm_testing.utils._typing import coerce_to_Path, PATH_OR_STR
+from cpac_slurm_testing.utils._typing import coerce_to_Path, PathStr
 
 
-def unlink(path: PATH_OR_STR, error: Literal["ignore", "raise"] = "ignore") -> None:
+def unlink(path: PathStr, error: Literal["ignore", "raise"] = "ignore") -> None:
     """Remove a path."""
     path = coerce_to_Path(path)
     unlink_method: str

--- a/src/cpac_slurm_testing/utils/utils.py
+++ b/src/cpac_slurm_testing/utils/utils.py
@@ -9,6 +9,10 @@ from cpac_slurm_testing.utils._typing import coerce_to_Path, PathStr
 class ExistingPath(Path):
     """A Path that definitely exists."""
 
+    def __new__(cls, *args, **kwargs) -> "ExistingPath":
+        """Construct a Path."""
+        return super().__new__(cls, *args, **kwargs)
+
     def __init__(self, /, *args, **kwargs) -> None:
         """Initialize an ExistingPath."""
         super().__init__(*args, **kwargs)

--- a/src/cpac_slurm_testing/utils/utils.py
+++ b/src/cpac_slurm_testing/utils/utils.py
@@ -1,8 +1,22 @@
 """General utilities."""
+from pathlib import Path
 from shutil import rmtree
 from typing import Literal
 
 from cpac_slurm_testing.utils._typing import coerce_to_Path, PathStr
+
+
+class ExistingPath(Path):
+    """A Path that definitely exists."""
+
+    def __init__(self, /, *args, **kwargs) -> None:
+        """Initialize an ExistingPath."""
+        super().__init__(*args, **kwargs)
+        if not self.exists():
+            for parent in reversed(self.parents):
+                parent.mkdir(mode=0o777, exist_ok=True)
+            self.mkdir(mode=0o777, exist_ok=True)
+        assert self.exists()
 
 
 def unlink(path: PathStr, error: Literal["ignore", "raise"] = "ignore") -> None:

--- a/src/cpac_slurm_testing/utils/utils.py
+++ b/src/cpac_slurm_testing/utils/utils.py
@@ -14,10 +14,21 @@ class ExistingPath(Path):
         instance = cast(ExistingPath, Path(*args, **kwargs))
         if not instance.exists():
             for parent in reversed(instance.parents):
-                parent.mkdir(mode=0o777, exist_ok=True)
-            instance.mkdir(mode=0o777, exist_ok=True)
+                ExistingPath._try_to_mk(parent)
+            ExistingPath._try_to_mk(instance)
         assert instance.exists()
         return instance
+
+    @staticmethod
+    def _try_to_mk(path: Path) -> None:
+        """Try to make paths, but don't fail unless path doeesn't exist in the end."""
+        if path.exists():
+            return
+        try:
+            path.mkdir(mode=0o777, exist_ok=True)
+        except Exception as e:
+            if not path.exists():
+                raise e
 
 
 def unlink(path: PathStr, error: Literal["ignore", "raise"] = "ignore") -> None:

--- a/src/cpac_slurm_testing/utils/utils.py
+++ b/src/cpac_slurm_testing/utils/utils.py
@@ -21,7 +21,7 @@ class ExistingPath(Path):
 
     @staticmethod
     def _try_to_mk(path: Path) -> None:
-        """Try to make paths, but don't fail unless path doeesn't exist in the end."""
+        """Try to make paths, but don't fail unless path doesn't exist in the end."""
         if path.exists():
             return
         try:

--- a/src/cpac_slurm_testing/utils/utils.py
+++ b/src/cpac_slurm_testing/utils/utils.py
@@ -1,6 +1,5 @@
 """General utilities."""
-import os
-from pathlib import Path, PosixPath, WindowsPath
+from pathlib import Path
 from shutil import rmtree
 from typing import cast, Literal
 
@@ -12,11 +11,7 @@ class ExistingPath(Path):
 
     def __new__(cls, *args, **kwargs) -> "ExistingPath":
         """Construct an ExistingPath."""
-        if cls is Path:
-            cls = cast(
-                type[ExistingPath], WindowsPath if os.name == "nt" else PosixPath
-            )
-        instance = cast(ExistingPath, object.__new__(cls))
+        instance = cast(ExistingPath, Path(*args, **kwargs))
         if not instance.exists():
             for parent in reversed(instance.parents):
                 parent.mkdir(mode=0o777, exist_ok=True)

--- a/src/cpac_slurm_testing/utils/utils.py
+++ b/src/cpac_slurm_testing/utils/utils.py
@@ -1,7 +1,8 @@
 """General utilities."""
-from pathlib import Path
+import os
+from pathlib import Path, PosixPath, WindowsPath
 from shutil import rmtree
-from typing import Literal
+from typing import cast, Literal
 
 from cpac_slurm_testing.utils._typing import coerce_to_Path, PathStr
 
@@ -10,17 +11,18 @@ class ExistingPath(Path):
     """A Path that definitely exists."""
 
     def __new__(cls, *args, **kwargs) -> "ExistingPath":
-        """Construct a Path."""
-        return super().__new__(cls, *args, **kwargs)
-
-    def __init__(self, /, *args, **kwargs) -> None:
-        """Initialize an ExistingPath."""
-        super().__init__(*args, **kwargs)
-        if not self.exists():
-            for parent in reversed(self.parents):
+        """Construct an ExistingPath."""
+        if cls is Path:
+            cls = cast(
+                type[ExistingPath], WindowsPath if os.name == "nt" else PosixPath
+            )
+        instance = cast(ExistingPath, object.__new__(cls))
+        if not instance.exists():
+            for parent in reversed(instance.parents):
                 parent.mkdir(mode=0o777, exist_ok=True)
-            self.mkdir(mode=0o777, exist_ok=True)
-        assert self.exists()
+            instance.mkdir(mode=0o777, exist_ok=True)
+        assert instance.exists()
+        return instance
 
 
 def unlink(path: PathStr, error: Literal["ignore", "raise"] = "ignore") -> None:


### PR DESCRIPTION
<!-- If you'd like use an emoji in the PR title, consider checking https://gitmoji.dev for guidance on emoji selection. Clicking an emoji image on that page will copy it to your clipboard. -->
## Related to
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- The square brackets in the template represent something for you to replace. For example, you might change "Fixes #[issue number]" to "Fixes #1". -->
Related to https://github.com/orgs/FCP-INDI/projects/5 by @FCP-INDI
 
## Description
<!-- Concisely describe what the pull request does. -->
* Adds [full run template SLURM script](https://github.com/childmindresearch/C-PAC_slurm_testing/blob/99723639d05943131c8cec0dbd6ad3a419d5bbc7/src/cpac_slurm_testing/templates/full_run.ftxt)
* Adds `data_scope` positional parameter to CLI https://github.com/childmindresearch/C-PAC_slurm_testing/blob/99723639d05943131c8cec0dbd6ad3a419d5bbc7/src/cpac_slurm_testing/utils/_typing.py#L7 https://github.com/childmindresearch/C-PAC_slurm_testing/blob/99723639d05943131c8cec0dbd6ad3a419d5bbc7/src/cpac_slurm_testing/status/cli.py#L100-L104
* Adds handling of different data trees for lite and full raw data on <img alt="bridges-2" src="https://github.com/user-attachments/assets/180e0f77-2131-474a-b39a-095c5981b9a1" height="14px"> https://github.com/childmindresearch/C-PAC_slurm_testing/blob/99723639d05943131c8cec0dbd6ad3a419d5bbc7/src/cpac_slurm_testing/utils/datapaths.py#L85-L127
* Updates internal logic to accommodate these changes for both lite and full runs.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `main` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
